### PR TITLE
De-obfuscate Python

### DIFF
--- a/shipwright/base.py
+++ b/shipwright/base.py
@@ -192,8 +192,8 @@ def expand(branch, tree):
     return [
         [
             d,
-            d.replace(last_built_ref=branch),
-            d.replace(last_built_ref='latest'),
+            d._replace(last_built_ref=branch),
+            d._replace(last_built_ref='latest'),
         ]
         for d in dependencies.brood(tree)
     ]

--- a/shipwright/base.py
+++ b/shipwright/base.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 from . import build
 from . import push
 from . import purge
-from . import fn
 from . import commits
 from . import docker
 
@@ -190,14 +189,14 @@ def expand(branch, tree):
     ]
 
     """
-    return fn.flat_map(
-        fn.juxt(
-            fn.identity,
-            fn.replace(last_built_ref=branch),
-            fn.replace(last_built_ref="latest")
-        ),
-        dependencies.brood(tree)
-    )
+    return [
+        [
+            d,
+            d.replace(last_built_ref=branch),
+            d.replace(last_built_ref='latest'),
+        ]
+        for d in dependencies.brood(tree)
+    ]
 
 
 def unit(tree):

--- a/shipwright/base.py
+++ b/shipwright/base.py
@@ -14,7 +14,7 @@ from . import dependencies
 from . import query
 
 from .container import containers as list_containers, container_name
-from .fn import curry, compose
+from .fn import curry
 
 
 class Shipwright(object):
@@ -46,13 +46,14 @@ class Shipwright(object):
             docker.tags_from_containers(client, containers)  # list of tags
         ))
 
-        current_rel = map(
-            compose(
-                commits.last_commit_relative(self.source_control, commit_map),
-                fn.getattr('dir_path')
-            ),
-            containers
-        )
+        current_rel = [
+            commits.last_commit_relative(
+                self.source_control,
+                commit_map,
+                c.dir_path,
+            )
+            for c in containers
+        ]
 
         # [[Container], [Tag], [Int], [Int]] -> [Target]
         return [

--- a/shipwright/build.py
+++ b/shipwright/build.py
@@ -58,11 +58,11 @@ def build(client, git_rev, container):
     # This can probably be replaced this issue is fixed - ideally we'd use the
     # 'decode' option on client.build to receive already parsed JSON objects.
     #   https://github.com/docker/docker-py/issues/1059
-    buffer = ''
+    buffer = b''
 
     def process_event_(buffer, data):
         buffer += data
-        for line in buffer.split('\r\n'):
+        for line in buffer.split(b'\r\n'):
             if not line:
                 continue
 

--- a/shipwright/build.py
+++ b/shipwright/build.py
@@ -1,8 +1,7 @@
 import os
+import re
 
-from . import fn
-
-from .fn import curry, maybe, flat_map, merge
+from .fn import curry, flat_map, merge
 
 from .tar import mkcontext
 
@@ -66,20 +65,28 @@ def build(client, git_rev, container):
     return (process_event_(evt) for evt in build_evts)
 
 
-@fn.composed(maybe(fn._0), fn.search(r'^Successfully built ([a-f0-9]+)\s*$'))
+RE_SUCCESS = re.compile(r'^Successfully built ([a-f0-9]+)\s*$')
+
 def success(line):
     """
     >>> success('Blah')
     >>> success('Successfully built 1234\\n')
     '1234'
     """
+    match = RE_SUCCESS.search(line)
+    if match:
+        return match.group(1)
+    return None
 
 
-@fn.composed(fn.first, fn.filter(None), fn.map(success))
 def success_from_stream(stream):
     """
-
     >>> stream = iter(('Blah', 'Successfully built 1234\\n'))
     >>> success_from_stream(stream)
     '1234'
     """
+    for x in stream:
+        result = success(x)
+        if result:
+            return result
+    return None

--- a/shipwright/build.py
+++ b/shipwright/build.py
@@ -55,6 +55,9 @@ def build(client, git_rev, container):
     # Docker correctly, and so the build API yields *chunks*, rather than the
     # valid JSON objects that it is documented as yielding.
     # We therefore maintain a buffer and read our own valid JSON out of that.
+    # This can probably be replaced this issue is fixed - ideally we'd use the
+    # 'decode' option on client.build to receive already parsed JSON objects.
+    #   https://github.com/docker/docker-py/issues/1059
     buffer = ''
 
     def process_event_(buffer, data):

--- a/shipwright/build.py
+++ b/shipwright/build.py
@@ -7,6 +7,8 @@ from .tar import mkcontext
 
 from .compat import json_loads
 
+RE_SUCCESS = re.compile(r'^Successfully built ([a-f0-9]+)\s*$')
+
 
 # (container->(str -> None))
 #   -> (container -> stream)
@@ -64,8 +66,6 @@ def build(client, git_rev, container):
 
     return (process_event_(evt) for evt in build_evts)
 
-
-RE_SUCCESS = re.compile(r'^Successfully built ([a-f0-9]+)\s*$')
 
 def success(line):
     """

--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -180,26 +180,22 @@ def run(repo, arguments, client_cfg, environ):
     if command_name == 'push':
         args.append(not arguments.pop('--no-build'))
 
+    dump_file = None
     if arguments['--dump-file']:
         dump_file = open(arguments['--dump-file'], 'w')
-        writer = fn.compose(
-            switch,
-            fn.tap(streamout(dump_file))
-        )
-    else:
-        writer = switch
 
     for event in command(*args):
         show_fn = mk_show(event)
-        formatted_message = writer(event)
+        formatted_message = streamout(event, dump_file)
         if formatted_message is not None:
-            show_fn(writer(event))
+            show_fn(streamout(event, dump_file))
 
 
-@fn.curry
-def streamout(f, event):
-    f.write(json.dumps(event))
-    f.write('\n')
+def streamout(event, dump_file):
+    if dump_file:
+        dump_file.write(json.dumps(event))
+        dump_file.write('\n')
+    return switch(event)
 
 
 def exit(msg):

--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -112,7 +112,6 @@ from shipwright.version import version
 
 from shipwright.dependencies import dependents, exact, exclude, upto
 from shipwright.colors import rainbow
-from shipwright.fn import _0
 from shipwright import fn
 
 
@@ -162,10 +161,7 @@ def run(repo, arguments, client_cfg, environ):
     client = docker.Client(version='1.18', **client_cfg)
     commands = ['build', 'push', 'purge']
     # {'publish': false, 'purge': true, ...} = 'purge'
-    command_name = _0([
-        c for c in commands
-        if arguments[c]
-    ]) or "build"
+    command_name = [c for c in commands if arguments[c]][0] or "build"
 
     command = getattr(Shipwright(config, repo, client), command_name)
 

--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -161,7 +161,8 @@ def run(repo, arguments, client_cfg, environ):
     client = docker.Client(version='1.18', **client_cfg)
     commands = ['build', 'push', 'purge']
     # {'publish': false, 'purge': true, ...} = 'purge'
-    command_name = [c for c in commands if arguments[c]][0] or "build"
+    command_names = [c for c in commands if arguments[c]]
+    command_name = command_names[0] if command_names else "build"
 
     command = getattr(Shipwright(config, repo, client), command_name)
 

--- a/shipwright/commits.py
+++ b/shipwright/commits.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .fn import curry, maybe, identity
+from .fn import curry, maybe
 from . import compat
 
 
@@ -38,7 +38,7 @@ def max_commit(commit_map, commits):
                 compat.python2_sort_key(c_map),
                 compat.python2_sort_key(ident),
             )
-        return max(([identity(c), commit_map(c)] for c in commits), key=key)
+        return max(([c, commit_map(c)] for c in commits), key=key)
     else:
         return [None, -1]
 

--- a/shipwright/container.py
+++ b/shipwright/container.py
@@ -56,7 +56,7 @@ def containers(name_func, path):
     >>> other = test_root.mkdir('other')
     >>> _ = other.mkdir('subdir1')
     >>> other.mkdir('subdir2').join('empty.txt').write('')
-    >>> containers(fn.identity, str(test_root)) # doctest: +ELLIPSIS
+    >>> containers(lambda x: x, str(test_root)) # doctest: +ELLIPSIS
     [Container(...), Container(...), Container(...), Container(...)]
     """
     return [

--- a/shipwright/docker.py
+++ b/shipwright/docker.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
-from shipwright import fn
-from shipwright.fn import curry, compose, flatten
+from shipwright.fn import curry
 
 
 def key_from_image_name(image_name):
@@ -25,20 +24,13 @@ def key_from_image_info(image_info_dict):
 
 @curry
 def last_built_from_docker(client, name):
-    return compose(
-        list,
-        flatten,
-        fn.fmap(key_from_image_info)  # {.. 'RepoTags': [...]} -> [...]
-    )(client.images(name))
+    images = client.images(name)
+    return list([x for i in images for x in key_from_image_info(i)])
 
 
-# client -> [containers] -> [[DockerTag]]
 @curry
 def tags_from_containers(client, containers):
-    return map(
-        compose(last_built_from_docker(client), fn.getattr('name')),
-        containers
-    )
+    return [last_built_from_docker(client, c.name) for c in containers]
 
 
 def encode_tag(tag):

--- a/shipwright/docker.py
+++ b/shipwright/docker.py
@@ -1,19 +1,16 @@
 from __future__ import absolute_import
 from shipwright import fn
-from shipwright.fn import _1, curry, compose, flatten
+from shipwright.fn import curry, compose, flatten
 
 
-@fn.composed(_1, fn.split(':'))
 def key_from_image_name(image_name):
     """
     >>> key_from_image_name('shipwright/blah:1234')
     '1234'
     """
+    return image_name.split(':', 1)[1]
 
 
-# DockerTag = str
-# {} -> [DockerTag]
-@fn.composed(fn.map(key_from_image_name), fn.getitem('RepoTags'))
 def key_from_image_info(image_info_dict):
     """
     >>> key_from_image_info({
@@ -23,6 +20,7 @@ def key_from_image_info(image_info_dict):
     ... })
     ['6e29823388f8', 'test']
     """
+    return [key_from_image_name(t) for t in image_info_dict['RepoTags']]
 
 
 @curry

--- a/shipwright/fn.py
+++ b/shipwright/fn.py
@@ -71,13 +71,6 @@ def compose(*fns):
     return compose_
 
 
-def apply(fn):
-    @wraps(fn)
-    def _(arr):
-        return fn(*arr)
-    return _
-
-
 def juxt(*fns):
     """
     >>> juxt(len)("blah")

--- a/shipwright/fn.py
+++ b/shipwright/fn.py
@@ -23,8 +23,6 @@ except ImportError:
 from functools import partial, wraps, reduce as ft_reduce
 import inspect
 
-import re
-
 
 def curry(f):
     """
@@ -202,18 +200,6 @@ def startswith(s1, s2):
     return s2.startswith(s1)
 
 
-def search(pattern, string=None):
-    def search(string):
-        m = re.search(pattern, string)
-        if m:
-            return m.groups()
-
-    if string is None:
-        return search
-    else:
-        return search(string)
-
-
 # sequence funcs
 flatten = chain.from_iterable
 
@@ -234,10 +220,6 @@ def flat_map(f, arr):
     return flatten(fmap(f, arr))
 
 
-def const(val):
-    return lambda x: val
-
-
 # Dict functions
 @curry
 def getitem(key, hashmap):
@@ -254,10 +236,6 @@ def merge(d1, d2):
 # object functions
 
 
-def identity(obj):
-    return obj
-
-
 @curry
 def getattr(attr, obj):
     return __builtin__.getattr(obj, attr)
@@ -267,36 +245,3 @@ def getattr(attr, obj):
 def setattr(attr, value, obj):
     __builtin__.setattr(obj, attr, value)
     return obj
-
-
-# namedtuples
-def replace(**kw):
-    def _replace(nt):
-        return nt._replace(**kw)
-    return _replace
-
-
-@curry
-def debug(fn, value):
-    """
-    Pause the python interpreter prior to calling a funtion. Useful
-    during development to inspect composed functions.
-
-    Imagine you have some long chain of composed functions
-
-    composed_fun = compose(some, long, function, chain)
-
-    You can stick a debug in the middle of it to inspect the result
-    before and after the function to the left is called.
-
-    So in this case wrapping function with a debug alows us to
-    inspect the input and output of it prior to being passed
-    to the long function.
-
-    composed_fun = compose(some, long, debug(function), chain)
-
-    """
-    import pdb
-    pdb.set_trace()
-    ret = fn(value)
-    return ret

--- a/shipwright/fn.py
+++ b/shipwright/fn.py
@@ -93,16 +93,6 @@ def juxt(*fns):
 
 
 @curry
-def tap(fn, val):
-    fn(val)
-    return val
-
-show = tap(print)
-
-print_fun = print
-
-
-@curry
 def catch(fn, on_error, value):
     """
     Given a function and an error handler  returns a function

--- a/shipwright/fn.py
+++ b/shipwright/fn.py
@@ -234,61 +234,8 @@ def flat_map(f, arr):
     return flatten(fmap(f, arr))
 
 
-@curry
-def filter(fn, sequence):
-    return list(__builtin__.filter(fn, sequence))
-
-
-def empty(seq):
-    return len(seq) == 0
-
-
-def first(arr):
-    """
-    >>> first([1,2,3])
-    1
-    """
-    return arr[0]
-
-
-def last(arr):
-    """
-    >>> last([1,2,3])
-    3
-    """
-    return arr[-1]
-
-
-@curry
-def slice(start, stop, seq):
-    return seq[start:stop]
-
-
-@curry
-def get(index, arr):
-    """
-    Returns the item in the array at the given index or None.
-    """
-    if index > len(arr) - 1:
-        return None
-    else:
-        return arr[index]
-
-
 def const(val):
     return lambda x: val
-
-# Convienance getters
-_0 = get(0)
-_1 = get(1)
-_2 = get(2)
-_3 = get(3)
-_4 = get(4)
-_5 = get(5)
-_6 = get(6)
-_7 = get(7)
-_8 = get(8)
-_9 = get(9)
 
 
 # Dict functions

--- a/shipwright/fn.py
+++ b/shipwright/fn.py
@@ -71,37 +71,6 @@ def compose(*fns):
     return compose_
 
 
-def composed(*fns):
-    """
-    Decorater to compose functions and write a doc test at the same time.
-    The function being decorated exists simply to document the composition.
-
-    For example if we have these 3 functions
-
-    >>> def first(a):
-    ...   return a + 2
-
-    >>> def second(b):
-    ...   return b + 10
-
-    >>> def third(c):
-    ...   return c - 5
-
-
-    We can compose them with decorator, note the body of bogus_func
-    is never called.
-
-    >>> @composed(first, second, third)
-    ... def bogus_func(int):
-    ...    "... insert a doc test here ..."
-
-
-    """
-    def dec(f):
-        return wraps(f)(compose(*fns))
-    return dec
-
-
 def apply(fn):
     @wraps(fn)
     def _(arr):

--- a/shipwright/push.py
+++ b/shipwright/push.py
@@ -1,7 +1,5 @@
 from . import compat
-from .fn import (
-    compose, curry, fmap, flat_map, merge
-)
+from .fn import curry, flat_map
 
 
 @curry
@@ -12,14 +10,11 @@ def do_push(client, images):
 @curry
 def push(client, image_tag):
     image, tag = image_tag
-    return fmap(
-        compose(
-            merge(dict(event="push", image=image)),
-            compat.json_loads,
-        ),
-        client.push(
-            image,
-            tag,
-            stream=True
-        )
-    )
+
+    def fmt(s):
+        d = compat.json_loads(s)
+        d.update({'event': 'push', 'image': image})
+        return d
+
+    results = client.push(image, tag, stream=True)
+    return [fmt(r) for r in results]


### PR DESCRIPTION
Aims:
- Simplify control flow, be more Pythonic, take advantage of Python syntax, rather than implementing features that require Haskell syntax to be readable.
- Use built-in Python functionality instead of Haskell-style utils.
- More debuggable (better stacktraces).
- ...without sacrificing the speed too much.

This is very much a work in progress.

I realise the value of concepts like currying and composition, and in languages where they are first-class features (like Haskell), they work well because APIs are all designed with them in mind, and developers read the code assuming those concepts. However when applied to Python like this, they only serve to surprise, and obfuscate the true meaning of the code, making ongoing maintenance hard, and making it more difficult for new developers to contribute to the project. For this reason, I'm attempting to refactor dockhand into a more Pythonic form.
